### PR TITLE
Change the dependency declaration from 'api' to 'implementation'

### DIFF
--- a/lib-snapcast-android/build.gradle.kts
+++ b/lib-snapcast-android/build.gradle.kts
@@ -55,7 +55,7 @@ android {
 }
 
 dependencies {
-    api(project(mapOf("path" to ":snapcast-deps")))
+    implementation(project(mapOf("path" to ":snapcast-deps")))
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)


### PR DESCRIPTION
By changing the declaration from api to implementation we aim to reduce the apk file size back to around ~30MB