### PR TITLE
Change snapserver sampleformat to 44.1

### DIFF
--- a/app/src/main/java/tech/capullo/radio/viewmodels/RadioViewModel.kt
+++ b/app/src/main/java/tech/capullo/radio/viewmodels/RadioViewModel.kt
@@ -223,11 +223,20 @@ class RadioViewModel @Inject constructor(
         fpb: String?
     ) = withContext(Dispatchers.IO) {
         val pb = if (isSnapserver) {
+            val streamName = "name=RadioCapullo"
+            val pipeMode = "mode=read"
+            val dryoutMs = "dryout_ms=2000"
+            val librespotSampleFormat = "sampleformat=44100:16:2"
+            val pipeArgs = listOf(
+                streamName, pipeMode, dryoutMs, librespotSampleFormat
+            ).joinToString("&")
+
             ProcessBuilder()
                 .command(
                     "$nativeLibDir/libsnapserver.so",
-                    "--server.datadir=$cacheDir", "--stream.source",
-                    "pipe://$filifoFilepath?name=fil&mode=create&dryout_ms=2000"
+                    "--server.datadir=$cacheDir",
+                    "--stream.source",
+                    "pipe://$filifoFilepath?$pipeArgs",
                 )
                 .redirectErrorStream(true)
         } else {


### PR DESCRIPTION
fix: Change snapserver sampleformat to 44.1 when using librespot. Reference: https://github.com/badaix/snapcast/blob/develop/doc/configuration.md#librespot

fix: Change pipe creation mode to readonly since the pipe is not created by the snapserver process. Reference: https://github.com/badaix/snapcast/blob/develop/doc/configuration.md#pipe